### PR TITLE
add support for the simpler functions in Xresources.h

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ lib/X11/Xlib/XEvent.pm
 lib/X11/Xlib/XID.pm
 lib/X11/Xlib/XRectangle.pm
 lib/X11/Xlib/XRenderPictFormat.pm
+lib/X11/Xlib/XrmDatabase.pm
 lib/X11/Xlib/XSetWindowAttributes.pm
 lib/X11/Xlib/XSizeHints.pm
 lib/X11/Xlib/XVisualInfo.pm
@@ -45,5 +46,7 @@ t/37-input-kb.t
 t/40-screen-attrs.t
 t/42-window.t
 t/43-pixmap.t
+t/50-resources.t
 t/70-xcomposite.t
+t/xresources
 t/lib/X11/SandboxServer.pm

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,8 @@ BEGIN {
         'ExtUtils::MakeMaker' => 0,
     );
     %TEST_REQUIRES= (
-        'Test::More'   => 0,
+        'Test::More'   => 1.001014,
+        'Test::TempDir::Tiny' => 0,
     );
     %PREREQ_PM= (
         'Try::Tiny'    => 0,

--- a/Xlib.xs
+++ b/Xlib.xs
@@ -1653,8 +1653,7 @@ XrmLocaleOfDatabase(database)
     XrmDatabase database
 
 void
-XrmDestroyDatabase(IN_OUT database)
-    XrmDatabase database
+XrmDestroyDatabase(IN_OUT XrmDatabase database)
   CODE:
     XrmDestroyDatabase( database );
     database = NULL;

--- a/Xlib.xs
+++ b/Xlib.xs
@@ -1653,8 +1653,11 @@ XrmLocaleOfDatabase(database)
     XrmDatabase database
 
 void
-XrmDestroyDatabase(database)
+XrmDestroyDatabase(IN_OUT database)
     XrmDatabase database
+  CODE:
+    XrmDestroyDatabase( database );
+    database = NULL;
 
 void
 XrmSetDatabase( display, database)

--- a/cpanfile
+++ b/cpanfile
@@ -3,3 +3,8 @@ requires 'Test::More'          => "0";
 requires 'Devel::CheckLib'     => "1.03";
 requires "ExtUtils::Depends"   => "0.405";
 requires "Try::Tiny"           => "0";
+
+on test => sub {
+  requires 'Test::TempDir::Tiny';
+  requires 'Test::More' => 1.001014;
+};

--- a/lib/X11/Xlib.pm
+++ b/lib/X11/Xlib.pm
@@ -1473,7 +1473,7 @@ Retrieve a resource with the given C<$name> and C<$class>.  C<$bool> is true if
 the resource was found.  If C<$type> is C<String>, C<$value> contains a string.
 Otherwise, it is up to the user to decode it,
 
-=head3 XrmPutResource( IN_OUT XrmDatabaseMaybe database, specifier, type, value )
+=head3 XrmPutResource( XrmDatabaseMaybe database, specifier, type, value )
 
   XrmPutResource( $database, $specifier, $type, $value );
 
@@ -1483,7 +1483,7 @@ the handle stored in C<$database>.  If C<$type> is C<String>, the
 C<$value> is assumed to be a Perl string and will be stored as a
 string, otherwise it is stored as is.
 
-=head3 XrmPutStringResource( IN_OUT XrmDatabaseMaybe database, specifier, value )
+=head3 XrmPutStringResource( XrmDatabaseMaybe database, specifier, value )
 
   XrmPutStringResource( $database, $specifier, $value );
 
@@ -1491,7 +1491,7 @@ Store the resource as a string the specified database.  If C<$database> is
 C<undef> or not an existing database, a new one will be created and
 the handle stored in C<$database>.
 
-=head3 XrmPutLineResource( IN_OUT XrmDatabaseMaybe database, line )
+=head3 XrmPutLineResource( XrmDatabaseMaybe database, line )
 
   XrmPutLineResource( $database, $line );
 

--- a/lib/X11/Xlib.pm
+++ b/lib/X11/Xlib.pm
@@ -86,6 +86,11 @@ my %_functions= (
     char_to_keysym codepoint_to_keysym keysym_to_char keysym_to_codepoint )],
   fn_pix => [qw( XCreateBitmapFromData XCreatePixmap
     XCreatePixmapFromBitmapData XFreePixmap )],
+  fn_resources => [qw( XResourceManagerString XScreenResourceString
+    XrmCombineDatabase XrmCombineFileDatabase XrmDestroyDatabase
+    XrmGetFileDatabase XrmGetResource XrmGetStringDatabase XrmInitialize
+    XrmLocaleOfDatabase XrmMergeDatabases XrmPutFileDatabase
+    XrmPutLineResource XrmPutResource XrmPutStringResource XrmSetDatabase )],
   fn_screen => [qw( DefaultColormap DefaultDepth DefaultGC DefaultScreen
     DefaultVisual DisplayHeight DisplayHeightMM DisplayWidth DisplayWidthMM
     RootWindow ScreenCount )],
@@ -1360,6 +1365,139 @@ Return the key code corresponding to C<$keysym> in the current mapping.
   XBell($display, $percent)
 
 Make the X server emit a sound.
+
+=head2 RESOURCE FUNCTIONS
+
+These functions provide an interface to the X resources manager and databases. Functions
+whose first parameter is a databse handle may be used as methods on the handle by importing
+L<X11::Xib::XrmDatabase>.
+
+=head3 XrmInitialize
+
+  XrmInitialize();
+
+Initialize the resource manager.
+
+=head3 XrmGetFileDatabase
+
+  $database = XrmGetFileDatabase( $filename );
+
+Create a resource database from an X resource file.
+
+=head3 XrmPutFileDatabase
+
+  XrmPutFileDatabase( $database, $filename );
+
+Write the database to the specified file.
+
+=head3 XResourceManagerString
+
+  $string = XResourceManagerString( $display );
+
+Return the C<RESOURCE_MANAGER> property from the root window of screen zero.
+
+=head3 XScreenResourceString
+
+  $string = XScreenResourceString( $screen );
+
+Return the C<SCREEN_RESOURCES> property from the root window of the specified screen.
+
+=head3 XrmGetStringDatabase
+
+  $database = XrmGetStringDatabase( $data );
+
+Create a new database from resources specified in the string specified in C<$data>.  The string
+should have the same format as an X resource file.
+
+=head3 XrmLocaleOfDatabase
+
+  $string = XrmLocaleOfDatabase( $database );
+
+Return the name of the locale bound to the database.
+
+=head3 XrmDestroyDatabase(database)
+
+  XrmDestroyDatabase( $database );
+
+Destroy the specified database.  A database is also automatically destroyed when it goes out of scope.
+
+=head3 XrmSetDatabase
+
+  XrmSetDatabase( $display, $database );
+
+Associate the resource database with the display.
+
+=head3 XrmGetDatabase
+
+  $database = XrmGetDatabase( $display );
+
+Return the database associated with the display.
+
+=head3 XrmCombineFileDatabase
+
+  $status = XrmCombineFileDatabase( $filename, $target_db, $override );
+
+Merge the contents of a resource file into a database. If C<$target_db>
+is undef or not an existing database, it will be set to a newly
+created database.
+
+If C<$override> is true, entries in C<$filename> will replace those in
+C<$target_db>.
+
+Returns zero if there is an error.
+
+=head3 XrmCombineDatabase
+
+  XrmCombineDatabase( $source_db, $target_db, $override );
+
+Merge the contents of C<$source_db> into C<$target_db>.
+If C<$override> is true, entries in C<$source_db> will replace those
+in C<$target_db>.
+
+If C<$target_db> is undef or not an existing database, it be set to
+C<$source_db>.
+
+C<$source_db> will be invalidated by this function.
+
+=head3 XrmMergeDatabases
+
+   XrmMergeDatabases( $source_db, $target_db );
+
+The same as calling L</XrmCombinDatabase> with C<$override = 1>.
+
+=head3 XrmGetResource
+
+  ($bool, $type, $value ) = XrmGetResource( $database, $name, $class );
+
+Retrieve a resource with the given C<$name> and C<$class>.  C<$bool> is true if
+the resource was found.  If C<$type> is C<String>, C<$value> contains a string.
+Otherwise, it is up to the user to decode it,
+
+=head3 XrmPutResource( IN_OUT XrmDatabaseMaybe database, specifier, type, value )
+
+  XrmPutResource( $database, $specifier, $type, $value );
+
+Store the resource in the specified database.  If C<$database> is
+C<undef> or not an existing database, a new one will be created and
+the handle stored in C<$database>.  If C<$type> is C<String>, the
+C<$value> is assumed to be a Perl string and will be stored as a
+string, otherwise it is stored as is.
+
+=head3 XrmPutStringResource( IN_OUT XrmDatabaseMaybe database, specifier, value )
+
+  XrmPutStringResource( $database, $specifier, $value );
+
+Store the resource as a string the specified database.  If C<$database> is
+C<undef> or not an existing database, a new one will be created and
+the handle stored in C<$database>.
+
+=head3 XrmPutLineResource( IN_OUT XrmDatabaseMaybe database, line )
+
+  XrmPutLineResource( $database, $line );
+
+Store the resource record in the database. If C<$database> is
+C<undef> or not an existing database, a new one will be created and
+the handle stored in C<$database>.
 
 =head2 EXTENSION XCOMPOSITE
 

--- a/lib/X11/Xlib/XrmDatabase.pm
+++ b/lib/X11/Xlib/XrmDatabase.pm
@@ -8,36 +8,121 @@ use X11::Xlib;
 # All modules in dist share a version
 our $VERSION = '0.20';
 
-*XrmPutFileDatabase = \&X11::Xlib::XrmPutFileDatabase;
-*XrmLocaleOfDatabase = \&X11::Xlib::XrmLocaleOfDatabase;
-*XrmDestroyDatabase = \&X11::Xlib::XrmDestroyDatabase;
-*XrmCombineDatabase = \&X11::Xlib::XrmCombineDatabase;
-*XrmMergeDatabases = \&X11::Xlib::XrmMergeDatabases;
-*XrmGetResource = \&X11::Xlib::XrmGetResource;
-*XrmPutResource = \&X11::Xlib::XrmPutResource;
-*XrmPutStringResource = \&X11::Xlib::XrmPutStringResource;
-*XrmPutLineResource = \&X11::Xlib::XrmPutLineResource;
+# these are in the order they appear in the Xlib.xs file to make it
+# easier to check for completeness.
+
+sub GetFileDatabase {
+    my ( $class, $file ) = @_;
+    X11::Xlib::XrmGetFileDatabase( $filename );
+};
+
+*PutFileDatabase   = \&X11::Xlib::XrmPutFileDatabase;
+
+# XResourceManagerString: unimplemented
+# XScreenResourceString: unimplemented
+
+sub GetStringDatabase {
+    my ( $class, $string ) = @_;
+    X11::Xlib::XrmGetStringDatabase( $string );
+}
+
+*LocaleOfDatabase  = \&X11::Xlib::XrmLocaleOfDatabase;
+
+*DestroyDatabase   = \&X11::Xlib::XrmDestroyDatabase;
+
+# XrmSetDatabase: unimplemented
+# XrmGetDatabase: unimplemented
+# XrmCombineFileDatabase: unimplemented
+
+*CombineDatabase   = \&X11::Xlib::XrmCombineDatabase;
+
+*MergeDatabases    = \&X11::Xlib::XrmMergeDatabases;
+
+*GetResource       = \&X11::Xlib::XrmGetResource;
+
+*PutResource       = \&X11::Xlib::XrmPutResource;
+
+*PutStringResource = \&X11::Xlib::XrmPutStringResource;
+
+*PutLineResource   = \&X11::Xlib::XrmPutLineResource;
 
 1;
 
 =head1 NAME
 
-X11::Xlib::XrmDatabase - Shadow class for X Resource Manager databases
-
+X11::Xlib::XrmDatabase - Object-Oriented Convenience Class for X Resource Manager Databases.
 
 =head1 SYNOPSIS
 
-To make the methods available:
-
   use X11::Xlib::XrmDatabase;
 
-Otherwise, they are as available as functions when using L<X11::Xlib>.
+  $db = X11::Xlib::XrmDatabase->GetFileDatabase( $file );
+  $db = X11::Xlib::XrmDatabase->GetStringDatabase( $string );
 
 =head1 DESCRIPTION
 
-See L<X11::Lib/RESOURCE FUNCTIONS> for more details.  Any C<Xrm>
-function whose first parameter is an X Resource database handle can be
-used as a method after importing this module.
+This module provides some object-oriented support for X Resource
+Manager Databases. The method name is derived from the function name
+by removing the C<Xrm> prefix, e.g. if the function name is
+
+  XrmGetFileDatabase
+
+the associated method will be
+
+  GetFileDatabase
+
+Not all of the Resource Manager functionality is exposed here.
+
+For more information see L<X11::Lib/RESOURCE FUNCTIONS>.
+
+=head1 CONSTRUCTORS
+
+=head2 GetFileDatabase
+
+  $db = X11::Xlib::XrmDatabase->GetFileDatabase( $file );
+
+=head2 GetStringDatabase
+
+  $db = X11::Xlib::XrmDatabase->GetStringDatabase( $string );
+
+=head1 METHODS
+
+=head2 PutFileDatabase
+
+  $db->PutFileDatabase( $filename );
+
+=head2 LocaleOfDatabse
+
+  $string = $db->LocaleOfDatabase;
+
+=head2 DestroyDatabase
+
+  $db->DestroyDatabase
+
+=head2 CombineDatabase
+
+  $db->CombineDatabase( $target_db, $override );
+
+=head2 MergeDatabases
+
+  $db->MergeDatabases( $target_db );
+
+=head2 GetResource
+
+  ($bool, $type, $value ) = $db->GetResource( $name, $class );
+
+=head2 PutResource
+
+  $db->PutResource( $specifier, $type, $value );
+
+=head2 PutStringResource
+
+  $db->PutStringResource( $specifier, $value );
+
+=head2 PutLineResource
+
+  $db->PutLineResource( $line );
+
 
 =head1 AUTHOR
 

--- a/lib/X11/Xlib/XrmDatabase.pm
+++ b/lib/X11/Xlib/XrmDatabase.pm
@@ -1,0 +1,56 @@
+package X11::Xlib::XrmDatabase;
+
+use strict;
+use warnings;
+
+use X11::Xlib;
+
+# All modules in dist share a version
+our $VERSION = '0.20';
+
+*XrmPutFileDatabase = \&X11::Xlib::XrmPutFileDatabase;
+*XrmLocaleOfDatabase = \&X11::Xlib::XrmLocaleOfDatabase;
+*XrmDestroyDatabase = \&X11::Xlib::XrmDestroyDatabase;
+*XrmCombineDatabase = \&X11::Xlib::XrmCombineDatabase;
+*XrmMergeDatabases = \&X11::Xlib::XrmMergeDatabases;
+*XrmGetResource = \&X11::Xlib::XrmGetResource;
+*XrmPutResource = \&X11::Xlib::XrmPutResource;
+*XrmPutStringResource = \&X11::Xlib::XrmPutStringResource;
+*XrmPutLineResource = \&X11::Xlib::XrmPutLineResource;
+
+1;
+
+=head1 NAME
+
+X11::Xlib::XrmDatabase - Shadow class for X Resource Manager databases
+
+
+=head1 SYNOPSIS
+
+To make the methods available:
+
+  use X11::Xlib::XrmDatabase;
+
+Otherwise, they are as available as functions when using L<X11::Xlib>.
+
+=head1 DESCRIPTION
+
+See L<X11::Lib/RESOURCE FUNCTIONS> for more details.  Any C<Xrm>
+function whose first parameter is an X Resource database handle can be
+used as a method after importing this module.
+
+=head1 AUTHOR
+
+Diab Jerius, E<lt>djerius@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2021 by Diab Jerius
+
+Copyright (C) 2021 by Smithsonian Astrophysical Observatory.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself, either Perl version 5.10.0 or,
+at your option, any later version of Perl 5 you may have available.
+
+=cut

--- a/lib/X11/Xlib/XrmDatabase.pm
+++ b/lib/X11/Xlib/XrmDatabase.pm
@@ -12,7 +12,7 @@ our $VERSION = '0.20';
 # easier to check for completeness.
 
 sub GetFileDatabase {
-    my ( $class, $file ) = @_;
+    my ( $class, $filename ) = @_;
     X11::Xlib::XrmGetFileDatabase( $filename );
 };
 

--- a/t/50-resources.t
+++ b/t/50-resources.t
@@ -1,0 +1,130 @@
+#! /usr/bin/env perl
+
+use v5.10;
+
+use strict;
+use warnings;
+
+use Test::More 1.001014;
+use Test::TempDir::Tiny;
+
+use X11::Xlib qw( :fn_resources );
+use X11::Xlib::XrmDatabase;
+
+my $HALF1 = <<'END';
+xmh*Paned*activeForeground:     red
+*incorporate.Foreground:     blue
+END
+
+my $HALF2 = <<'END';
+xmh.toc*Command*activeForeground:     green
+xmh.toc*?.Foreground:     white
+xmh.toc*Command.activeForeground:     black
+END
+
+my $StringDB = $HALF1 . $HALF2;
+
+
+
+XrmInitialize();
+
+sub test_db {
+    my $db = shift;
+
+    my ( $bool, $type, $value ) = $db->XrmGetResource(
+        'xmh.toc.messagefunctions.incorporate.activeForeground',
+        'Xmh.Paned.Box.Command.Foreground'
+    );
+
+    is( !!$bool, 1,        'success' );
+    is( $type,   'String', 'type' );
+    is( $value,  'black',  "value" );
+}
+
+subtest 'File' => sub {
+    test_db( XrmGetFileDatabase( 't/xresources' ) );
+};
+
+subtest String => sub {
+    test_db( XrmGetStringDatabase( $StringDB ) )
+};
+
+sub Put {
+    my ( $db, $put ) = @_;
+    $put->( $db, 'xmh*Paned*activeForeground',       'red' );
+    $put->( $db, '*incorporate.Foreground',          'blue' );
+    $put->( $db, 'xmh.toc*Command*activeForeground', 'green' );
+    $put->( $db, 'xmh.toc*?.Foreground',             'white' );
+    $put->( $db, 'xmh.toc*Command.activeForeground', 'black' );
+    test_db( $db );
+}
+
+sub test_put {
+    my $put = shift;
+    subtest 'explicit create' => \&Put, XrmGetStringDatabase( '' ), $put;
+    subtest 'implicit create' => \&Put, undef, $put;
+}
+
+subtest Put => sub {
+    test_put sub { XrmPutResource( $_[0], $_[1], 'String', $_[2] ) };
+};
+
+subtest PutString => sub {
+    test_put sub { XrmPutStringResource(@_) };
+};
+
+subtest PutLine => sub {
+    test_put sub { XrmPutLineResource( $_[0], $_[1] . ': ' . $_[2] ) };
+};
+
+subtest PutFileDatabase => sub {
+    my $db = XrmGetStringDatabase( $StringDB );
+
+    in_tempdir "method" => sub {
+        $db->XrmPutFileDatabase( "resources" );
+        my $ndb = XrmGetFileDatabase( "resources" );
+        test_db( $ndb );
+    };
+
+};
+
+subtest CombineFileDatabase => sub {
+    my $filename = 'resources';
+
+    subtest methods => sub {
+        in_tempdir "PutFile" => sub {
+            my $source_db = XrmGetStringDatabase( $HALF1 );
+            $source_db->XrmPutFileDatabase( $filename );
+            my $target_db = XrmGetStringDatabase( $HALF2 );
+            my $ok = XrmCombineFileDatabase( $filename, $target_db, 1 );
+            ok( $ok, 'XrmCombineFileDatabase' );
+            test_db( $target_db );
+        };
+    };
+
+};
+
+subtest CombineDatabase => sub {
+
+    subtest methods => sub {
+        my $source_db = XrmGetStringDatabase( $HALF1 );
+        my $target_db = XrmGetStringDatabase( $HALF2 );
+        $source_db->XrmCombineDatabase( $target_db, 1 );
+        test_db( $target_db );
+    };
+
+};
+
+subtest MergeDatabases => sub {
+
+    subtest methods => sub {
+        my $source_db = XrmGetStringDatabase( $HALF1 );
+        my $target_db = XrmGetStringDatabase( $HALF2 );
+        $source_db->XrmMergeDatabases( $target_db );
+        test_db( $target_db );
+    };
+
+};
+
+
+done_testing;

--- a/t/50-resources.t
+++ b/t/50-resources.t
@@ -1,7 +1,5 @@
 #! /usr/bin/env perl
 
-use v5.10;
-
 use strict;
 use warnings;
 

--- a/t/50-resources.t
+++ b/t/50-resources.t
@@ -22,17 +22,15 @@ END
 
 my $StringDB = $HALF1 . $HALF2;
 
-
-
 XrmInitialize();
 
 sub test_db {
     my $db = shift;
 
-    my ( $bool, $type, $value ) = $db->GetResource(
+    my ( $bool, $type, $value )
+      = $db->GetResource(
         'xmh.toc.messagefunctions.incorporate.activeForeground',
-        'Xmh.Paned.Box.Command.Foreground'
-    );
+        'Xmh.Paned.Box.Command.Foreground' );
 
     is( !!$bool, 1,        'success' );
     is( $type,   'String', 'type' );
@@ -44,7 +42,7 @@ subtest 'File' => sub {
 };
 
 subtest String => sub {
-    test_db( XrmGetStringDatabase( $StringDB ) )
+    test_db( XrmGetStringDatabase( $StringDB ) );
 };
 
 sub Put {
@@ -68,7 +66,7 @@ subtest Put => sub {
 };
 
 subtest PutString => sub {
-    test_put sub { XrmPutStringResource(@_) };
+    test_put sub { XrmPutStringResource( @_ ) };
 };
 
 subtest PutLine => sub {
@@ -89,38 +87,32 @@ subtest PutFileDatabase => sub {
 subtest CombineFileDatabase => sub {
     my $filename = 'resources';
 
-    subtest methods => sub {
-        in_tempdir "PutFile" => sub {
-            my $source_db = XrmGetStringDatabase( $HALF1 );
-            $source_db->PutFileDatabase( $filename );
-            my $target_db = XrmGetStringDatabase( $HALF2 );
-            my $ok = XrmCombineFileDatabase( $filename, $target_db, 1 );
-            ok( $ok, 'XrmCombineFileDatabase' );
-            test_db( $target_db );
-        };
+    in_tempdir "PutFile" => sub {
+        my $source_db = XrmGetStringDatabase( $HALF1 );
+        $source_db->PutFileDatabase( $filename );
+        my $target_db = XrmGetStringDatabase( $HALF2 );
+        my $ok = XrmCombineFileDatabase( $filename, $target_db, 1 );
+        ok( $ok, 'XrmCombineFileDatabase' );
+        test_db( $target_db );
     };
 
 };
 
 subtest CombineDatabase => sub {
 
-    subtest methods => sub {
-        my $source_db = XrmGetStringDatabase( $HALF1 );
-        my $target_db = XrmGetStringDatabase( $HALF2 );
-        $source_db->CombineDatabase( $target_db, 1 );
-        test_db( $target_db );
-    };
+    my $source_db = XrmGetStringDatabase( $HALF1 );
+    my $target_db = XrmGetStringDatabase( $HALF2 );
+    $source_db->CombineDatabase( $target_db, 1 );
+    test_db( $target_db );
 
 };
 
 subtest MergeDatabases => sub {
 
-    subtest methods => sub {
-        my $source_db = XrmGetStringDatabase( $HALF1 );
-        my $target_db = XrmGetStringDatabase( $HALF2 );
-        $source_db->MergeDatabases( $target_db );
-        test_db( $target_db );
-    };
+    my $source_db = XrmGetStringDatabase( $HALF1 );
+    my $target_db = XrmGetStringDatabase( $HALF2 );
+    $source_db->MergeDatabases( $target_db );
+    test_db( $target_db );
 
 };
 

--- a/t/50-resources.t
+++ b/t/50-resources.t
@@ -29,7 +29,7 @@ XrmInitialize();
 sub test_db {
     my $db = shift;
 
-    my ( $bool, $type, $value ) = $db->XrmGetResource(
+    my ( $bool, $type, $value ) = $db->GetResource(
         'xmh.toc.messagefunctions.incorporate.activeForeground',
         'Xmh.Paned.Box.Command.Foreground'
     );
@@ -79,7 +79,7 @@ subtest PutFileDatabase => sub {
     my $db = XrmGetStringDatabase( $StringDB );
 
     in_tempdir "method" => sub {
-        $db->XrmPutFileDatabase( "resources" );
+        $db->PutFileDatabase( "resources" );
         my $ndb = XrmGetFileDatabase( "resources" );
         test_db( $ndb );
     };
@@ -92,7 +92,7 @@ subtest CombineFileDatabase => sub {
     subtest methods => sub {
         in_tempdir "PutFile" => sub {
             my $source_db = XrmGetStringDatabase( $HALF1 );
-            $source_db->XrmPutFileDatabase( $filename );
+            $source_db->PutFileDatabase( $filename );
             my $target_db = XrmGetStringDatabase( $HALF2 );
             my $ok = XrmCombineFileDatabase( $filename, $target_db, 1 );
             ok( $ok, 'XrmCombineFileDatabase' );
@@ -107,7 +107,7 @@ subtest CombineDatabase => sub {
     subtest methods => sub {
         my $source_db = XrmGetStringDatabase( $HALF1 );
         my $target_db = XrmGetStringDatabase( $HALF2 );
-        $source_db->XrmCombineDatabase( $target_db, 1 );
+        $source_db->CombineDatabase( $target_db, 1 );
         test_db( $target_db );
     };
 
@@ -118,7 +118,7 @@ subtest MergeDatabases => sub {
     subtest methods => sub {
         my $source_db = XrmGetStringDatabase( $HALF1 );
         my $target_db = XrmGetStringDatabase( $HALF2 );
-        $source_db->XrmMergeDatabases( $target_db );
+        $source_db->MergeDatabases( $target_db );
         test_db( $target_db );
     };
 

--- a/t/xresources
+++ b/t/xresources
@@ -1,0 +1,5 @@
+xmh*Paned*activeForeground:     red
+*incorporate.Foreground:     blue
+xmh.toc*Command*activeForeground:     green
+xmh.toc*?.Foreground:     white
+xmh.toc*Command.activeForeground:     black

--- a/typemap
+++ b/typemap
@@ -150,7 +150,6 @@ T_PTROBJ_SPECIAL
    else
       sv_setref_pv($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\", (void*)$var);
 
-
 INPUT
 T_PTROBJ_SPECIAL_Maybe
   if (sv_isobject($arg) && sv_derived_from($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g; $ntt =~ s/Maybe$//;\$ntt}\")){

--- a/typemap
+++ b/typemap
@@ -28,8 +28,13 @@ PictFormat            O_X11_Xlib_XID
 Atom                  T_UV
 Time                  T_UV
 Bool                  T_BOOL
+Status                T_IV
 KeyCode               T_IV
 KeySym                T_IV
+Xpointer              T_PV
+XrmDatabase           T_PTROBJ_SPECIAL
+XrmDatabaseMaybe      T_PTROBJ_SPECIAL_Maybe
+XrmValue              O_X11_Xlib_XrmValue
 
 INPUT
 O_X11_Xlib
@@ -117,3 +122,51 @@ O_X11_Xlib_OpaqueOrNull
             dpy, $var, \"X11::Xlib::@{[ $type =~ /(\w+?)OrNull/ ]}\", SVt_PVMG, 1));
     else
         sv_setsv($arg, &PL_sv_undef);
+
+INPUT
+O_X11_Xlib_XrmValue
+     ${var}.size = SvCUR($arg);
+     ${var}.addr = SvPV_nolen($arg);
+
+OUTPUT
+O_X11_Xlib_XrmValue
+     sv_setpvn($arg, ${var}.addr, ${var}.size );
+
+INPUT
+T_PTROBJ_SPECIAL
+  if (sv_isobject($arg) && sv_derived_from($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\")){
+    IV tmp = SvIV((SV*)SvRV($arg));
+    $var = INT2PTR($type, tmp);
+  }
+  else
+    croak(\"$var is not of type X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\");
+
+OUTPUT
+T_PTROBJ_SPECIAL
+   if(sv_isobject($arg) ) {
+     SV* tmp = (SV*)(SvRV($arg) );
+     sv_setiv( tmp, PTR2IV($var) );
+   }
+   else
+      sv_setref_pv($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\", (void*)$var);
+
+
+INPUT
+T_PTROBJ_SPECIAL_Maybe
+  if (sv_isobject($arg) && sv_derived_from($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g; $ntt =~ s/Maybe$//;\$ntt}\")){
+    IV tmp = SvIV((SV*)SvRV($arg));
+    $var = INT2PTR($type, tmp);
+  }
+  else {
+    $var = NULL;
+  }
+
+OUTPUT
+T_PTROBJ_SPECIAL_Maybe
+   if(sv_isobject($arg) ) {
+     SV* tmp = (SV*)(SvRV($arg) );
+     sv_setiv( tmp, PTR2IV($var) );
+   }
+   else
+     sv_setref_pv($arg, \"X11::Xlib::${(my $ntt=$ntype)=~s/_/::/g; $ntt =~ s/Maybe$//;\$ntt}\",
+                 (void*)$var);


### PR DESCRIPTION
This PR adds support for the more straightforward X resource manager functions in Xresources.h.

It doesn't expose the Quark versions of the functions, or the enumeration capability.

It adds new test dependencies on Test::TempDir::Tiny as well as a version of Test:::More which supports `subtest` (which has been around for a while!).

I've tested it on Perl 5.10.1 and 5.30.0.