### PR TITLE
Use correct length for the XGetWindowProperty/XChangeProperty data.

### DIFF
--- a/Xlib.xs
+++ b/Xlib.xs
@@ -738,11 +738,11 @@ XGetWindowProperty(dpy, wnd, prop_atom, long_offset, long_length, delete, req_ty
             &actual_type, &actual_format, &nitems, &bytes_after, (unsigned char**)&data);
         if (RETVAL == Success) {
             if (actual_format == 8) {
-                sv_setpvn(data_out, data, nitems);
+                sv_setpvn(data_out, data, nitems*sizeof(char));
             } else if (actual_format == 16) {
-                sv_setpvn(data_out, data, nitems*2);
+                sv_setpvn(data_out, data, nitems*sizeof(short));
             } else if (actual_format == 32) {
-                sv_setpvn(data_out, data, nitems*4);
+                sv_setpvn(data_out, data, nitems*sizeof(long));
             } else {
                 XFree(data);
                 croak("Un-handled 'actual_format' value %d returned by XGetWindowProperty", actual_format);
@@ -767,9 +767,9 @@ XChangeProperty(dpy, wnd, prop_atom, type, format, mode, data, nelements)
     SV *data
     int nelements
     INIT:
-        int bytelen= format == 8? nelements
-            : format == 16? nelements * 2
-            : format == 32? nelements * 4
+        int bytelen= format == 8? nelements * sizeof(char)
+            : format == 16? nelements * sizeof(short)
+            : format == 32? nelements * sizeof(long)
             : -1;
         size_t svlen;
         char *buffer;


### PR DESCRIPTION
The Xlib.xs code for `XGetWindowProperty`/`XChangeProperty` assumes format 32 means the data is chucks of 4 bytes. But the manuals for `XGetWindowProperty`/`XChangeProperty` says the data is an array of longs. So on a system with `sizeof(long) > 4` the data returned by `XGetWindowProperty` gets truncated.

This change replaces the hard coded data lengths with the sizeof the corrrespond data type.

FYI I hit this problem initially when trying when getting the `_NET_CLIENT_LIST` property and getting 0 for XIDs. Searching around I found [Correct size of Window type for XGetWindowProperty](https://stackoverflow.com/questions/44020616/correct-size-of-window-type-for-xgetwindowproperty) which indicated the underlying problem.

A simple demonstration of the problem would be be getting the [`_NET_DESKTOP_GEOMETRY`](https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm46515148926400) property which should returns two `CARDINAL` i.e. the width and height of the desktop.

```perl
$ cat ../t.pl 
#!/usr/bin/perl
use strict;
use X11::Xlib;
my $display = X11::Xlib->new();
if(0 == $display->XGetWindowProperty(my $wnd = $display->RootWindow,
                                     my $prop_atom = $display->XInternAtom("_NET_DESKTOP_GEOMETRY", 0),
                                     my $offset = 0, my $length = 2, my $delete = 0,
                                     my $req_type = $display->XInternAtom("CARDINAL", 0),
                                     my $actual_type, my $actual_format, my $nitems, my $bytes_after, my $data))
{
    print "actual_type = ", $display->XGetAtomName($actual_type), ", ",
        "actual_format = $actual_format, ",
        "nitems = $nitems, ",
        "bytes_after = $bytes_after\n\n",
        "data = ", unpack("H*", $data), "\n\n",
        'unpack("L2", $data) = ', join(" ", unpack("L2", $data)), "\n",
        'unpack("Q2", $data) = ', join(" ", unpack("Q2", $data)), "\n";
}
```

Using `X11:Xlib` 0.20 release on a `x86_64` system

```
$ perl -MX11::Xlib -e 'print $X11::Xlib::VERSION, "\n";'
0.20
$ perl -MConfig -e 'print $Config{longsize}, "\n";'
8
$ perl ../t.pl
actual_type = CARDINAL, actual_format = 32, nitems = 2, bytes_after = 0

data = 8007000000000000

unpack("L2", $data) = 1920 0
unpack("Q2", $data) = 1920
```

The 8 bytes returned only contain the width and there is no more data to retrieve (bytes_after = 0).

With this change I get 16 bytes of data which when extracted as 64 bit values gives both width and height.

```
$ perl -Mblib ../t.pl 
actual_type = CARDINAL, actual_format = 32, nitems = 2, bytes_after = 0

data = 80070000000000003804000000000000

unpack("L2", $data) = 1920 0
unpack("Q2", $data) = 1920 1080
```